### PR TITLE
Remove unneeded vcsclean script call

### DIFF
--- a/cron/cron.sh
+++ b/cron/cron.sh
@@ -108,7 +108,6 @@ do
 			git clone http://git.php.net/repository/php-src.git -b $GITBRANCH $PHPTAG
 			cd ${PHPTAG}
 		fi
-		./vcsclean
 		git clean -xfd > /dev/null
 		cp "../config.$PHPTAG" config.nice
 


### PR DESCRIPTION
The `vcsclean` shell script from the php-src repository is a simple wrapper
around the command of `git -Xfd` and is in the process of being moved from
the root location in the php-src repository in newer PHP branches to a more
dedicated place inside the scripts directory.

This particular call here is even not necessary because there is a
git clean call done one line below after it.

cc @nikic 
discussion: https://github.com/php/php-src/pull/3589

Thank you.